### PR TITLE
chore: bump version 0.2.2 → 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Types of changes:
 
 ## [Unreleased]
 
+---
+
+## [1.0.0] - 2026-03-17
+
 ### Added
 
 - `main()` function in `src/app.py` for testability

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Copy directory tree into file, e.g. README.md, instead of manual effort.
 
-![Version](https://img.shields.io/badge/version-0.2.2-8A2BE2)
+![Version](https://img.shields.io/badge/version-1.0.0-8A2BE2)
 [![pytest](https://github.com/qte77/gha-dirtree-to-readme/actions/workflows/pytest.yaml/badge.svg)](https://github.com/qte77/gha-dirtree-to-readme/actions/workflows/pytest.yaml)
 [![test-action](https://github.com/qte77/gha-dirtree-to-readme/actions/workflows/test-dirtree-readme-action.yaml/badge.svg)](https://github.com/qte77/gha-dirtree-to-readme/actions/workflows/test-dirtree-readme-action.yaml)
 [![CodeQL](https://github.com/qte77/gha-dirtree-to-readme/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/gha-dirtree-to-readme/actions/workflows/codeql.yaml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "0.2.2"
+version = "1.0.0"
 name = "dirtree-readme-action"
 description = "Copy directory tree into file, e.g. README.md, instead of manual effort."
 authors = [
@@ -46,7 +46,7 @@ ignore = [
 unfixable = ["B"]
 
 [tool.bumpversion]
-current_version = "0.2.2"
+current_version = "1.0.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true


### PR DESCRIPTION
Automated version bump via bump-my-version. Tag v1.0.0 already pushed.