### PR TITLE
chore: standardize repo scaffold

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "attribution": {
+    "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
+    "pr": "Generated with Claude <noreply@anthropic.com>"
+  },
+  "enabledPlugins": {
+    "commit-helper@qte77-claude-code-utils": true
+  },
+  "extraKnownMarketplaces": {
+    "qte77-claude-code-utils": {
+      "source": {
+        "source": "github",
+        "repo": "qte77/claude-code-utils-plugin"
+      }
+    }
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a problem
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear and concise description of the bug -->
+
+## Steps to Reproduce
+
+1. Run `...`
+2. ...
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened. Include error traces if applicable -->
+
+## Environment
+
+- OS/Runner:
+- Version:
+
+## Additional Context
+
+<!-- Screenshots, logs, related issues, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,15 @@
+---
+name: Question
+about: Ask a question not covered by the documentation
+title: ''
+labels: question
+assignees: ''
+---
+
+**Have you checked the docs?**
+
+- [ ] README.md
+
+## Question
+
+<!-- Your question here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+# Summary
+
+<!-- Brief description of what this PR does and why -->
+
+Closes <!-- #issue-number or N/A -->
+
+## Type of Change
+
+<!-- Check all that apply. Commit type must match conventional commits: feat|fix|build|chore|ci|docs|style|refactor|perf|revert|test -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `docs` — documentation only
+- [ ] `refactor` — no functional change
+- [ ] `test` — test additions or fixes
+- [ ] `ci` — CI/CD changes
+- [ ] `build` — build system or dependency changes
+- [ ] `perf` — performance improvement
+- [ ] `style` — formatting, whitespace (no logic change)
+- [ ] `revert` — reverts a previous commit
+- [ ] `chore` — tooling, config, maintenance
+- [ ] **Breaking change** — add `!` after commit type
+
+## Self-Review
+
+- [ ] I have reviewed my own diff and removed debug/dead code
+- [ ] Commit messages follow conventional commits format
+
+## Testing
+
+- [ ] Tests pass locally
+- [ ] CI workflows pass
+
+## Security
+
+- [ ] No hardcoded secrets, API keys, or credentials
+- [ ] No new injection vectors in workflow `run:` steps

--- a/.github/workflows/bump-my-version.yaml
+++ b/.github/workflows/bump-my-version.yaml
@@ -72,7 +72,9 @@ jobs:
               '{message: $msg, tree: $tree, parents: [$parent]}') \
             --jq '.sha')
 
-          gh api "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" -f sha="$COMMIT_SHA"
+          gh api "repos/$REPO/git/refs/heads/$BRANCH" -X PATCH -f sha="$COMMIT_SHA" -F force=true 2>/dev/null \
+            || gh api "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" -f sha="$COMMIT_SHA"
+
           gh api "repos/$REPO/git/refs" -f ref="refs/tags/v$VERSION" -f sha="$COMMIT_SHA"
 
           echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/qte77/gha-dirtree-to-readme/security/advisories/new).
+
+Do not open a public issue for security vulnerabilities.


### PR DESCRIPTION
## Summary

Standardize repository scaffold to match the qte77 org-wide pattern.

## Changes

- `.claude/settings.json` — attribution config + commit-helper plugin
- `SECURITY.md` — GitHub Security Advisories reporting link
- `.github/PULL_REQUEST_TEMPLATE.md` — conventional commits PR checklist
- `.github/ISSUE_TEMPLATE/` — bug report + question templates
- Resolved merge conflict in `bump-my-version.yaml`

Generated with Claude <noreply@anthropic.com>