### PR TITLE
ci: advance uv exclude-newer to 2026-04-23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ pythonpath = ["src"]
 
 [tool.uv]
 package = true
-exclude-newer = "2026-03-17T00:00:00Z"
+exclude-newer = "2026-04-23T00:00:00Z"
 
 [tool.ruff]
 target-version = "py312"

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12"
 
 [options]
-exclude-newer = "2026-03-17T00:00:00Z"
+exclude-newer = "2026-04-23T00:00:00Z"
 
 [[package]]
 name = "babel"
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "dirtree-readme-action"
-version = "1.0.0"
+version = "1.1.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Advance `[tool.uv] exclude-newer` from 2026-03-17 → 2026-04-23
- Regenerate `uv.lock`

Unblocks dependabot PRs (#62-#66): their bumps request package versions published after the prior cutoff, so `uv sync` fails with "No solution found when resolving dependencies".

Closes #73

## Test plan
- [ ] CI `pytest` job succeeds
- [ ] Rebase dependabot PRs #62-#66 and confirm they go green