### PR TITLE
ci: bump actions/checkout to v6 (Node 24 runtime)

### DIFF
--- a/.github/workflows/generate-deploy-mkdocs-ghpages.yaml
+++ b/.github/workflows/generate-deploy-mkdocs-ghpages.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
 
     - name: Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref:
           ${{

--- a/.github/workflows/links-fail-fast.yaml
+++ b/.github/workflows/links-fail-fast.yaml
@@ -20,7 +20,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -14,6 +14,6 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/ruff-action@v3
 ...


### PR DESCRIPTION
Clears the "Node.js 20 actions are deprecated" warning across 4 workflows.

GitHub forces Node 24 on runners from June 2, 2026 and removes Node 20 on September 16, 2026.

Verified `actions/checkout@v6.0.2` declares `using: node24` in its `action.yml`.