### PR TITLE
fix: update LICENSE.md reference to LICENSE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ These are read by `src/app.py` and can be overridden via `$GITHUB_ENV`.
 │ └── utils.py
 ├── action.yaml
 ├── CHANGELOG.md
-├── LICENSE.md
+├── LICENSE
 ├── mkdocs.yaml
 ├── pyproject.toml
 ├── README.md


### PR DESCRIPTION
Sample dirtree output in README showed `LICENSE.md` but the file is named `LICENSE`.

Closes #71